### PR TITLE
Basic support for different widget types

### DIFF
--- a/v2f-core/src/main/java/net/pdp7/v2f/core/DefaultConfiguration.java
+++ b/v2f-core/src/main/java/net/pdp7/v2f/core/DefaultConfiguration.java
@@ -13,6 +13,7 @@ import org.thymeleaf.spring4.view.ThymeleafViewResolver;
 import net.pdp7.v2f.core.dao.DAO;
 import net.pdp7.v2f.core.web.Router;
 import net.pdp7.v2f.core.web.ViewRenderer;
+import net.pdp7.v2f.core.web.WidgetPolicy;
 import net.pdp7.v2f.core.web.handlers.DetailHandler;
 import net.pdp7.v2f.core.web.handlers.IndexHandler;
 import net.pdp7.v2f.core.web.handlers.ListHandler;
@@ -28,8 +29,13 @@ public class DefaultConfiguration {
 	}
 
 	@Bean
+	public WidgetPolicy widgetPolicy() {
+		return new WidgetPolicy(1000);
+	}
+
+	@Bean
 	public DAO dao() {
-		return new DAO(dslContext, schemaCrawlerOptions(), v2fSchema);
+		return new DAO(dslContext, widgetPolicy(), schemaCrawlerOptions(), v2fSchema);
 	}
 
 	@Bean
@@ -49,7 +55,7 @@ public class DefaultConfiguration {
 
 	@Bean
 	public DetailHandler detailHandler() {
-		return new DetailHandler(dao(), viewRenderer());
+		return new DetailHandler(dao(), viewRenderer(), widgetPolicy());
 	}
 
 	@Bean

--- a/v2f-core/src/main/java/net/pdp7/v2f/core/dao/DAO.java
+++ b/v2f-core/src/main/java/net/pdp7/v2f/core/dao/DAO.java
@@ -12,6 +12,7 @@ import org.jooq.Field;
 import org.jooq.Record;
 
 import net.pdp7.v2f.core.web.Router;
+import net.pdp7.v2f.core.web.WidgetPolicy;
 import schemacrawler.schema.Catalog;
 import schemacrawler.schema.Table;
 import schemacrawler.schemacrawler.SchemaCrawlerOptions;
@@ -20,12 +21,14 @@ import schemacrawler.utility.SchemaCrawlerUtility;
 public class DAO {
 
 	protected final DSLContext dslContext;
+	protected final WidgetPolicy widgetPolicy;
 	protected final SchemaCrawlerOptions schemaCrawlerOptions;
 	protected Router router;
 	public final String v2fSchema;
 
-	public DAO(DSLContext dslContext, SchemaCrawlerOptions schemaCrawlerOptions, String v2fSchema) {
+	public DAO(DSLContext dslContext, WidgetPolicy widgetPolicy, SchemaCrawlerOptions schemaCrawlerOptions, String v2fSchema) {
 		this.dslContext = dslContext;
+		this.widgetPolicy = widgetPolicy;
 		this.schemaCrawlerOptions = schemaCrawlerOptions;
 		this.v2fSchema = v2fSchema;
 	}
@@ -99,7 +102,7 @@ public class DAO {
 		return dslContext
 				.select(field("_id"), field("_as_string"))
 				.from(table)
-				.fetch(record -> new RowWrapper(router, getCatalog(), table, record, null, v2fSchema));
+				.fetch(record -> new RowWrapper(router, getCatalog(), widgetPolicy, table, record, null, v2fSchema));
 	}
 
 	public static class DAOException extends RuntimeException {

--- a/v2f-core/src/main/java/net/pdp7/v2f/core/dao/RowWrapper.java
+++ b/v2f-core/src/main/java/net/pdp7/v2f/core/dao/RowWrapper.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.jooq.Record;
 
 import net.pdp7.v2f.core.web.Router;
+import net.pdp7.v2f.core.web.WidgetPolicy;
 import schemacrawler.schema.Catalog;
 import schemacrawler.schema.Column;
 
@@ -15,13 +16,15 @@ public class RowWrapper {
 	protected final String table;
 	protected final Router router;
 	protected final Catalog catalog;
+	protected final WidgetPolicy widgetPolicy;
 	/** non-null for new rows" */
 	protected final String newFormId;
 	protected final String v2fSchema;
 
-	public RowWrapper(Router router, Catalog catalog, String table, Record record, String newFormId, String v2fSchema) {
+	public RowWrapper(Router router, Catalog catalog, WidgetPolicy widgetPolicy, String table, Record record, String newFormId, String v2fSchema) {
 		this.router = router;
 		this.catalog = catalog;
+		this.widgetPolicy = widgetPolicy;
 		this.table = table;
 		this.record = record;
 		this.newFormId = newFormId;
@@ -68,6 +71,10 @@ public class RowWrapper {
 
 		public String getFormInputName() {
 			return router.getFormInputName(table, getId(), getName(), newFormId);
+		}
+
+		public String getWidgetName() {
+			return "widget-" + widgetPolicy.getWidgetName(column);
 		}
 	}
 }

--- a/v2f-core/src/main/java/net/pdp7/v2f/core/web/WidgetPolicy.java
+++ b/v2f-core/src/main/java/net/pdp7/v2f/core/web/WidgetPolicy.java
@@ -1,0 +1,20 @@
+package net.pdp7.v2f.core.web;
+
+import schemacrawler.schema.Column;
+
+public class WidgetPolicy {
+
+	protected int textAreaLengthThreshold;
+
+	public WidgetPolicy(int textAreaLengthThreshold) {
+		this.textAreaLengthThreshold = textAreaLengthThreshold;
+	}
+
+	public String getWidgetName(Column column) {
+		if (column.getType().getName().equals("text") && column.getSize() > textAreaLengthThreshold) {
+			return "textarea";
+		}
+		return "text";
+	}
+
+}

--- a/v2f-core/src/main/java/net/pdp7/v2f/core/web/handlers/DetailHandler.java
+++ b/v2f-core/src/main/java/net/pdp7/v2f/core/web/handlers/DetailHandler.java
@@ -9,16 +9,19 @@ import net.pdp7.v2f.core.dao.DAO;
 import net.pdp7.v2f.core.dao.RowWrapper;
 import net.pdp7.v2f.core.web.Router;
 import net.pdp7.v2f.core.web.ViewRenderer;
+import net.pdp7.v2f.core.web.WidgetPolicy;
 
 public class DetailHandler {
 
 	protected final DAO dao;
 	protected final ViewRenderer viewRenderer;
+	protected final WidgetPolicy widgetPolicy;
 	protected Router router;
 
-	public DetailHandler(DAO dao, ViewRenderer viewRenderer) {
+	public DetailHandler(DAO dao, ViewRenderer viewRenderer, WidgetPolicy widgetPolicy) {
 		this.dao = dao;
 		this.viewRenderer = viewRenderer;
+		this.widgetPolicy = widgetPolicy;
 	}
 
 	public void setRouter(Router router) {
@@ -33,6 +36,7 @@ public class DetailHandler {
 		RowWrapper row = new RowWrapper(
 				router,
 				dao.getCatalog(),
+				widgetPolicy,
 				table,
 				id == null ? null : dao.loadRecord(table, id),
 				id == null ? "0" : null,

--- a/v2f-core/src/main/resources/templates/detail.html
+++ b/v2f-core/src/main/resources/templates/detail.html
@@ -1,7 +1,7 @@
 <form th:action="${row.link}" method="post">
 	<label th:each="column: ${row.columns}" th:inline="text">
 		[[${column.name}]]
-		<input type="text" th:name="${column.formInputName}" th:value="${column.value}"/>
+		<input type="text" th:replace="${column.widgetName}::widget(${column})"/>
 	</label>
 	<input type="hidden" name="success_url" th:value="${success_url}"/>
 	<input type="submit" name="action" value="save"/>

--- a/v2f-core/src/main/resources/templates/widget-text.html
+++ b/v2f-core/src/main/resources/templates/widget-text.html
@@ -1,0 +1,1 @@
+<input th:fragment="widget(column)" type="text" th:name="${column.formInputName}" th:value="${column.value}"/>

--- a/v2f-core/src/main/resources/templates/widget-textarea.html
+++ b/v2f-core/src/main/resources/templates/widget-textarea.html
@@ -1,0 +1,1 @@
+<textarea th:fragment="widget(column)" th:name="${column.formInputName}" th:text="${column.value}"/>


### PR DESCRIPTION
At the moment, only implement a split into input of type text and a
textarea (using a configurable column length threshold). Calculate this
using a WidgetPolicy which selects different HTML templates to render
the widget.